### PR TITLE
Background transparency filter

### DIFF
--- a/demos/paper/app.css
+++ b/demos/paper/app.css
@@ -14,6 +14,9 @@
 .top-nav, .side-nav{
     position:relative;
 }
+.top-nav>label{
+    margin:0 1em;
+}
 .viewer-container{
     position:relative;
 }
@@ -28,7 +31,7 @@
     left:0;
 }
 .viewer-container.stacked .viewer:last-child .openseadragon-canvas{
-    opacity: 0.5;
+    opacity: var(--stacked-opacity);
 }
 .viewer-container.stacked .viewer:not(:last-child)>div:not([class]){
     opacity: 0;

--- a/demos/paper/index.html
+++ b/demos/paper/index.html
@@ -11,6 +11,7 @@
       <div class="top-nav">
         <label class="combine-label"><input type="checkbox" class="combine-checkbox">Combine</label>
         <label><input type="checkbox" class="sync-checkbox">Sync translation/rotation</label>
+        <label>Opacity of top image:<input class='opacity-slider' type="range" min="0" max="100" value="80"></label>
       </div>
       <div class="bottom-row">
         <div class="side-nav">
@@ -26,6 +27,7 @@
     <script src="/node_modules/jquery/dist/jquery.min.js"></script>
     <script src="/node_modules/underscore/underscore-min.js"></script>
     <script src="/node_modules/openseadragon/build/openseadragon/openseadragon.js"></script>
+    <script src="/node_modules/openseadragon-filtering/openseadragon-filtering.js"></script>
     
     <script src="/node_modules/paper/dist/paper-full.js"></script>
     <script src="/js/dsa/common.js"></script>

--- a/js/dsa/common.js
+++ b/js/dsa/common.js
@@ -171,7 +171,7 @@
           callback();
         });
         //         context.save();
-        //   OpenSeadragon.Filters.MO  RPHOLOGICAL_OPERATION(kernelSize, Math.max)
+        //   OpenSeadragon.Filters.MORPHOLOGICAL_OPERATION(kernelSize, Math.max)
         //         context.restore();
         //       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "jquery": "^3.6.3",
         "live-server": "^1.2.2",
         "openseadragon": "^4.0.0",
+        "openseadragon-filtering": "https://github.com/pearcetm/OpenSeadragonFiltering",
         "osd-paperjs-annotation": "https://github.com/pearcetm/osd-paperjs-annotation#6284a71",
         "paper": "^0.12.17",
         "underscore": "^1.13.6",
@@ -1347,6 +1348,14 @@
       "license": "BSD-3-Clause",
       "funding": {
         "url": "https://opencollective.com/openseadragon"
+      }
+    },
+    "node_modules/openseadragon-filtering": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/pearcetm/OpenSeadragonFiltering.git#132c3623dd3995ee7e55ad855803793a030af14e",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "openseadragon": ">=2.1"
       }
     },
     "node_modules/opn": {
@@ -3198,6 +3207,13 @@
     "openseadragon": {
       "version": "git+ssh://git@github.com/pearcetm/openseadragon.git#6ab8c9c930da9133722fe8655fde06922d120161",
       "from": "openseadragon@^4.0.0"
+    },
+    "openseadragon-filtering": {
+      "version": "git+ssh://git@github.com/pearcetm/OpenSeadragonFiltering.git#132c3623dd3995ee7e55ad855803793a030af14e",
+      "from": "openseadragon-filtering@https://github.com/pearcetm/OpenSeadragonFiltering",
+      "requires": {
+        "openseadragon": ">=2.1"
+      }
     },
     "opn": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "paper": "^0.12.17",
     "underscore": "^1.13.6",
     "webix": "^10.0.1",
-    "osd-paperjs-annotation": "https://github.com/pearcetm/osd-paperjs-annotation#6284a71"
+    "osd-paperjs-annotation": "https://github.com/pearcetm/osd-paperjs-annotation#6284a71",
+    "openseadragon-filtering":"https://github.com/pearcetm/OpenSeadragonFiltering"
   },
   "scripts": {
     "start": "live-server",


### PR DESCRIPTION
This adds a custom filter to the [openseadragon-filtering.js](https://github.com/usnistgov/OpenSeadragonFiltering) plugin that makes "glass" transparent, leaving only the tissue area opaque. The glass color is calculated as the median color of the edge pixels of the thumbnail image, and pixels within a small range of that color are considered "glass" and the alpha channel is set to a low number.

An opacity slider control at the top of the page adjusts the tissue opacity of the top image (only when viewers are stacked).

This is useful for better visualization of the registration of tissue between viewers.