### PR TITLE
Smarter glass auto-detect, seamless background color, and option UI

### DIFF
--- a/demos/paper/app.css
+++ b/demos/paper/app.css
@@ -36,6 +36,13 @@
     top:0;
     left:0;
 }
+.viewer{
+    background-color:transparent;
+    background-color:var(--background-color);
+}
+.viewer-container.stacked .viewer:not(:first-child){
+    background-color:transparent;
+}
 .cursor-target{
     font-weight:bold;
 }

--- a/demos/paper/index.html
+++ b/demos/paper/index.html
@@ -12,6 +12,7 @@
         <label class="combine-label"><input type="checkbox" class="combine-checkbox">Combine</label>
         <label><input type="checkbox" class="sync-checkbox">Sync translation/rotation</label>
         <label>Opacity of top image:<input class='opacity-slider' type="range" min="0" max="100" value="80"></label>
+        <label><input type="checkbox" class="glass-checkbox" checked>Transparent "glass"</label>
       </div>
       <div class="bottom-row">
         <div class="side-nav">


### PR DESCRIPTION
This PR does the following:
- Only auto-applies transparency to "glass" if 50%+ of the border is nearly the same color, indicating likely WSI
- Sets the viewer background-color property to the median "glass" color for consistency across viewing experiences
- Adds a checkbox to enable/disable transparent glass